### PR TITLE
Verificação prévia para conversão

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -55,7 +55,9 @@ class Format extends FormatAux
             $type = parent::returnTypeToConvert($arrRules);
             if (in_array('convert', $arrRules) && !empty($type)) {
                 try {
-                    $data[$key] = parent::executeConvert($type, $data[$key]);
+                    if (in_array($key, array_keys($data))) {
+                        $data[$key] = parent::executeConvert($type, $data[$key]);
+                    }
                 } catch (\Exception $ex) {
                     $error[] = "falhar ao tentar converter {$data[$key]} para $type";
                 }

--- a/tests/UnitTestFormat.php
+++ b/tests/UnitTestFormat.php
@@ -37,6 +37,7 @@ class UnitTestFormat extends TestCase
             'tratandoTipoFloat' => 'convert|float',
             'tratandoTipoBoolean' => 'convert|bool',
             'tratandoTipoNumeric' => 'convert|numeric',
+            'tratandoInexistente' => 'convert|bool',
         ];
         Format::convertTypes($data, $rules);
         self::assertIsInt($data['tratandoTipoInt']);
@@ -45,6 +46,7 @@ class UnitTestFormat extends TestCase
         self::assertIsFloat($data['tratandoTipoFloat']);
         self::assertIsBool($data['tratandoTipoBoolean']);
         self::assertIsNumeric($data['tratandoTipoNumeric']);
+        self::assertArrayNotHasKey('tratandoInexistente', $data);
     }
 
     public function testConvertTypesBool(): void


### PR DESCRIPTION
Criação de verificação prévia para conversão de parâmetros, evitando criação indevida de chaves em array de dados principal